### PR TITLE
Add initial support for TRACE_5G_NG (NGAP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Note that I'm not including an .sh script equivalent to the .bat script, since i
 | Diameter       | Transport protocol is assumed to be SCTP |
 | UserInterface  | Frames with content different from SIP, DNS, Diameter or RTP are treated as system log frames and embedded into Syslog messages with source and destination IPs set to 0.0.0.0. Comments for SIP and Diameter PTMF File Types apply to UserInterface frames with SIP and Diameter content too |
 | IP             | Transparent conversion (since the IP PTMF frames contain the whole Ethernet packet) |
+| NGAP TRACE_5G_NG | Transport protocol is assumed to be SCTP with fixed IP addresses. All additional headers are ignored. |
 
 The information in next section is very useful to understad the comments from the table above.
 

--- a/build-with-docker.sh
+++ b/build-with-docker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#
+docker run -it --rm  -v ${PWD}:/mnt -u 1000:1000 openjdk /bin/bash -c "cd /mnt && ./build.sh"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/ByteUtils.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/Pcap.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/PtmfFrame.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/UserInterfacePtmfFrame.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/SipPtmfFrame.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/DiameterPtmfFrame.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/NgapPtmfFrame.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/IpPtmfFrame.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/PtmfFile.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/Ui.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/Cli.java
+javac -classpath "bin" -d "bin" src/main/java/ptmf2pcap/Gui.java
+
+jar cvfm ptmf2pcap.jar src/main/resources/Manifest.txt -C "bin" .
+

--- a/src/main/java/ptmf2pcap/NgapPtmfFrame.java
+++ b/src/main/java/ptmf2pcap/NgapPtmfFrame.java
@@ -1,0 +1,120 @@
+package ptmf2pcap;
+import java.net.InetAddress;
+
+/**
+ * NgapPtmfFrame object represents a PTMF frame of NGAP type
+ *
+ * The frames of this type do not contain an Ethernet packet with all the upper layers,
+ * but contains just the NGAP layer. Thus:
+ *    - The transport protocol is assumed to be SCTP with port 38412 and hardcoded IP addresses 0.0.0.1 and 0.0.0.2
+ *    - MAC addresses, checksums and so on are filled with default values (typically zeroes)
+ */
+public class NgapPtmfFrame extends PtmfFrame {
+
+	/*
+	 * NgapPtmfFrame constants
+	 */
+	public static final int FRAME_HEADER_LENGTH = 72+4;
+	private static final int SRCIP_OFFSET = 10;
+	private static final int DSTIP_OFFSET = 14;
+	private static final int SRCPORT_OFFSET = 0;
+	private static final int DSTPORT_OFFSET = 0;
+	//
+	private static final byte[] AMF_IPV4_BYTES = { (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x01};
+	private static final byte[] GNB_IPV4_BYTES = { (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x02};
+
+	/**
+	 * Returns a NgapPtmfFrame object
+	 *
+	 * @return	The NgapPtmfFrame object
+	 */
+	public NgapPtmfFrame() {
+		super();
+	};
+
+	/**
+	 * Returns a NgapPtmfFrame object
+	 *
+	 * @param	byteContent	a byte array with the content of the frame
+	 * @return	The NgapPtmfFrame object
+	 */
+	public NgapPtmfFrame(byte[] byteContent) {
+		super(byteContent);
+	};
+
+	/**
+	 * Returns a NgapPtmfFrame object
+	 *
+	 * @param	byteContent	a byte array with the content of the frame
+	 * @param	order	the relative order of the frame
+	 * @return	The NgapPtmfFrame object
+	 */
+	public NgapPtmfFrame(byte[] byteContent, int order) {
+		super(byteContent, order);
+	};
+
+	/**
+	 * Returns the frame in an IPv4 packet
+	 * The transport layer is assumed to be SCTP
+	 *
+	 * @return	The IPv4 packet
+	 */
+	public byte[] getIpv4Packet() {
+		byte[] sctpPacket = null;
+		byte[] ipv4Packet = null;
+		InetAddress amfIp, gnbIp;
+		bool toAmf = true; //TODO: find position of this flag
+		//TODO: change ip depending on direction...
+		try {
+			amfIp = InetAddress.getByAddress(AMF_IPV4_BYTES);
+		} catch(Exception e) {
+			/*
+			 * This should never happen since the argument we are passing to
+			 * InetAddress.getByAddress is a constant whose value is correct,
+			 * but we need to provide try-catch anyway
+			 */
+			System.out.println("Exception when creating amfIp!!");
+			amfIp = null;
+		};
+		try {
+			gnbIp = InetAddress.getByAddress(GNB_IPV4_BYTES);
+		} catch(Exception e) {
+			/*
+			 * This should never happen since the argument we are passing to
+			 * InetAddress.getByAddress is a constant whose value is correct,
+			 * but we need to provide try-catch anyway
+			 */
+			System.out.println("Exception when creating gnbIp!!");
+			gnbIp = null;
+		};
+		if (toAmf){
+			sctpPacket = Pcap.createSctpPacket(38412, 38412, this.getBody(), gnbIp, amfIp);
+			ipv4Packet = Pcap.createIpv4Packet(gnbIp, amfIp, Pcap.IP_PROTOCOL_SCTP, sctpPacket);
+		}else{
+			sctpPacket = Pcap.createSctpPacket(38412, 38412, this.getBody(), amfIp, gnbIp);
+			ipv4Packet = Pcap.createIpv4Packet(amfIp, gnbIp, Pcap.IP_PROTOCOL_SCTP, sctpPacket);
+		}
+		return ipv4Packet;
+	};
+
+	/*
+	 * Member methods to access the static constants that are
+	 * defined/overriden at this class
+	 */
+	public int GET_FRAME_HEADER_LENGTH() {
+		return FRAME_HEADER_LENGTH;
+	};
+	public int GET_SRCIP_OFFSET() {
+		return SRCIP_OFFSET;
+	};
+	public int GET_DSTIP_OFFSET() {
+		return DSTIP_OFFSET;
+	};
+	public int GET_SRCPORT_OFFSET() {
+		return SRCPORT_OFFSET;
+	};
+	public int GET_DSTPORT_OFFSET() {
+		return DSTPORT_OFFSET;
+	};
+
+};

--- a/src/main/java/ptmf2pcap/PtmfFile.java
+++ b/src/main/java/ptmf2pcap/PtmfFile.java
@@ -29,16 +29,18 @@ public class PtmfFile {
 	public static final String FILETYPE_USERINTERFACE = "UserInterface";
 	public static final String FILETYPE_SIP = "SIP";
 	public static final String FILETYPE_DIAMETER = "Diameter";
+	public static final String FILETYPE_NGAP = "TRACE_5G_NG (NGAP)"; //TRACE_5G_NG
 	public static final String FILETYPE_IP = "IP";
 	public static final String FILETYPE_UNKNOWN = "UNKNOWN";
 	private static final String[][] FILETYPE_TABLE = {
 		{"01", FILETYPE_SIP},
 		{"03", FILETYPE_DIAMETER},
+		{"06", FILETYPE_NGAP},
 		{"10", FILETYPE_USERINTERFACE},
 		{"53", FILETYPE_IP}
 	};
 	private static HashMap<String,String> FILETYPE_MAP = createHashMap(FILETYPE_TABLE);
-	
+
 	/**
 	 * Creates a HashMap reading the (key, value) pairs from an input table
 	 *
@@ -52,45 +54,47 @@ public class PtmfFile {
 		};
 		return hashMap;
 	};
-	
+
 	/*
 	 * Instance variables
 	 */
 	private byte[] byteContent;
-	
+
 	/**
 	 * Constructor method taking a byte array as input parameter
 	 * The file type is inferred from the byte content
-	 * 
+	 *
 	 * @param	byteContent	a byte array with the content of the file
 	 * @return				the newly created PtmfFile object
 	 */
 	public PtmfFile(byte[] byteContent) {
 		this.byteContent = byteContent;
 	};
-	
+
 	/**
 	 * Infers the file type by analysing the byte content
 	 * It is only able to recognize some of the file types generated
 	 * by Huawei SBCs (at least those from SE2900 series)
-	 * 
+	 *
 	 * @return	The file type
 	 */
 	public String getFileType() {
 		String fileType = FILETYPE_MAP.get(this.getFileTypeHex());
+		System.out.println("FileType: "+fileType);
+		//System.out.println(this.toString());
 		if(fileType == null) {
 			fileType = FILETYPE_UNKNOWN;
 		}
 		return fileType;
 	};
-	
+
 	/**
 	 * @return	The byte content of the PtmfFile object
 	 */
 	public byte[] getByteContent() {
 		return this.byteContent;
 	};
-	
+
 	/**
 	 * Returns the content of the PtmfFile object represented as an Hex String
 	 *
@@ -99,7 +103,7 @@ public class PtmfFile {
 	public String toRawString() {
 		return ByteUtils.bytesToHexString(this.getByteContent());
 	};
-	
+
 	/**
 	 * Returns a string representation of the PTMF file
 	 * Hex representation is still used the same as toRawString() method does,
@@ -129,7 +133,7 @@ public class PtmfFile {
 		};
 		return stringBuilder.toString();
 	};
-	
+
 	/**
 	 * Returns the header of the PTMF file
 	 *
@@ -138,7 +142,7 @@ public class PtmfFile {
 	public byte[] getHeader() {
 		return ByteUtils.split(this.getByteContent(), FRAME_SEPARATOR_BYTES).get(0);
 	};
-	
+
 	/**
 	 * Returns the file type represented as a byte array
 	 *
@@ -147,7 +151,7 @@ public class PtmfFile {
 	public byte[] getFileTypeBytes() {
 		return ByteUtils.subarray(this.getByteContent(), FILETYPE_OFFSET, FILETYPE_LENGTH);
 	};
-	
+
 	/**
 	 * Returns the file type represented as an Hex String
 	 *
@@ -156,7 +160,7 @@ public class PtmfFile {
 	public String getFileTypeHex() {
 		return ByteUtils.bytesToHexString(this.getFileTypeBytes());
 	};
-	
+
 	/**
 	 * Checks whether the input fileType is supported or not
 	 *
@@ -164,7 +168,7 @@ public class PtmfFile {
 	 * @return				whether it is supported or not
 	 */
 	public static boolean isSupportedFileType(String fileType) {
-		if(fileType.equals(FILETYPE_USERINTERFACE) || fileType.equals(FILETYPE_SIP) || fileType.equals(FILETYPE_DIAMETER) || fileType.equals(FILETYPE_IP)) {
+		if(fileType.equals(FILETYPE_USERINTERFACE) || fileType.equals(FILETYPE_SIP) || fileType.equals(FILETYPE_DIAMETER) || fileType.equals(FILETYPE_IP) || fileType.equals(FILETYPE_NGAP)) {
 			return true;
 		} else {
 			return false;
@@ -190,7 +194,9 @@ public class PtmfFile {
 			ptmfFrame = new DiameterPtmfFrame(byteFrame, frameIndex);
 		} else if(fileType.equals(FILETYPE_IP)) {
 			ptmfFrame = new IpPtmfFrame(byteFrame, frameIndex);
-		} else {
+		} else if(fileType.equals(FILETYPE_NGAP)) {
+			ptmfFrame = new NgapPtmfFrame(byteFrame, frameIndex);
+		} else{
 			ptmfFrame = null;
 		};
 		return ptmfFrame;
@@ -232,7 +238,7 @@ public class PtmfFile {
 		};
 		return ptmfFrameList;
 	};
-	
+
 	/**
 	 * Returns a PCAP file containing all the PTMF frames that the PtmfFile contains
 	 *


### PR DESCRIPTION
This adds inirial support for TRACE_5G_NG Frames as captured by Huawei BTS5900 5G LamSite gNodeB.

Parsing of the extra headers still need to be added. Current version just extracts the NGAP payload and passes this into a pcap file.